### PR TITLE
timeline test increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .coverage
 coverage.xml
 coverage.lcov
+.vscode
+.python-version
+bounties_api/cover

--- a/bounties_api/analytics/tests.py
+++ b/bounties_api/analytics/tests.py
@@ -5,8 +5,10 @@ import unittest
 # Create your tests here.
 from std_bounties.constants import EXPIRED_STAGE, DEAD_STAGE, COMPLETED_STAGE, ACTIVE_STAGE, DRAFT_STAGE
 from analytics.management.commands.timeline_generator import diff_time, diff_days, day_bounds, range_days, \
-    get_bounty_draft, get_bounty_completed, get_bounty_active, get_bounty_expired, get_bounty_dead
-from std_bounties.models import BountyState
+    get_bounty_draft, get_bounty_completed, get_bounty_active, get_bounty_expired, get_bounty_dead, \
+    get_fulfillment_acceptance_rate, get_bounty_fulfilled_rate, get_avg_fulfiller_acceptance_rate, \
+    get_avg_fulfillment_amount, get_total_fulfillment_amount, generate_timeline
+from std_bounties.models import BountyState, Fulfillment, Bounty
 
 
 class DateUtilsTest(unittest.TestCase):
@@ -43,6 +45,86 @@ class DateUtilsTest(unittest.TestCase):
         for index in range(1, 366):
             day = next(iterator).timetuple().tm_yday
             self.assertEqual(day, index)
+
+
+class TimelineTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        accepted_date = datetime(2018, 1, 1, 0, 0)
+        bounties = [
+            Bounty(id=x,
+            bounty_id=x, 
+            fulfillmentAmount=x,
+            usd_price=x,
+            deadline=accepted_date,
+            paysTokens=True) for x in range(0, 25)
+        ]
+        bountyStages = [
+            *[BountyState(bounty=bounties[x], bountyStage=COMPLETED_STAGE, change_date=accepted_date) for x in range(0, 5)],
+            *[BountyState(bounty=bounties[x], bountyStage=EXPIRED_STAGE, change_date=accepted_date) for x in range(5, 10)],
+            *[BountyState(bounty=bounties[x], bountyStage=ACTIVE_STAGE, change_date=accepted_date) for x in range(10, 15)],
+            *[BountyState(bounty=bounties[x], bountyStage=DRAFT_STAGE, change_date=accepted_date) for x in range(15, 20)],
+            *[BountyState(bounty=bounties[x], bountyStage=DEAD_STAGE, change_date=accepted_date) for x in range(20, 25)]
+        ]
+        fulfillments = [
+            Fulfillment(fulfillment_id=x,
+            accepted_date=accepted_date if x % 2 == 0 else None,
+            bounty=bounties[x],
+            fulfiller=x%3,
+            accepted=x % 2 == 0,
+            fulfillment_created=accepted_date) for x in range(0, 5)
+        ]
+
+        for bounty in bounties:
+            bounty.save()
+        for bountyStage in bountyStages:
+            bountyStage.save()
+        for fullfilment in fulfillments:
+            fullfilment.save()
+        
+
+    def test_get_fulfillment_acceptance_rate(self):
+        data = Fulfillment.objects.filter(fulfillment_created__lte=datetime(2018, 1, 1, 0, 0))
+        self.assertEqual(get_fulfillment_acceptance_rate(data), 0.6)
+
+    def test_get_bounty_fulfilled_rate(self):
+        data = Fulfillment.objects.filter(fulfillment_created__lte=datetime(2018, 1, 1, 0, 0))
+        bounties = Bounty.objects.all()
+        self.assertEqual(get_bounty_fulfilled_rate(data, bounties), 0.2)
+
+    def test_get_avg_fulfiller_acceptance_rate(self):
+        data = Fulfillment.objects.filter(fulfillment_created__lte=datetime(2018, 1, 1, 0, 0))
+        self.assertAlmostEqual(get_avg_fulfiller_acceptance_rate(data), 0.6666666666666666)
+
+    def test_get_avg_fulfillment_amount(self):
+        data = BountyState.objects.filter(change_date__lte=datetime(2018, 1, 1, 0, 0))
+        self.assertEqual(get_avg_fulfillment_amount(data), 2.0)
+
+    def test_get_total_fulfillment_amount(self):
+        data = BountyState.objects.filter(change_date__lte=datetime(2018, 1, 1, 0, 0))
+        self.assertEqual(get_total_fulfillment_amount(data), 10)
+
+    def test_generate_timeline(self):
+        result = generate_timeline([datetime(2018, 1, 1, 0, 0), datetime(2018, 1, 1, 0, 0)], 'standardSchema')
+        self.assertEqual(result.date, datetime(2018, 1, 1, 0, 0))
+        self.assertEqual(result.bounties_issued, 5)
+        self.assertEqual(result.bounties_issued_cum, 25)
+        self.assertEqual(result.fulfillments_submitted_cum, 5)
+        self.assertEqual(result.fulfillments_submitted, 5)
+        self.assertEqual(result.fulfillments_accepted_cum, 3)
+        self.assertEqual(result.fulfillments_accepted, 3)
+        self.assertEqual(result.fulfillments_pending_acceptance, 2)
+        self.assertEqual(result.fulfillment_acceptance_rate, 0.6)
+        self.assertEqual(result.bounty_fulfilled_rate, 0.25)
+        self.assertAlmostEqual(result.avg_fulfiller_acceptance_rate, 0.6666666666666666)
+        self.assertEqual(result.avg_fulfillment_amount, 2)
+        self.assertEqual(result.total_fulfillment_amount, 10)
+        self.assertEqual(result.bounty_draft, 5)
+        self.assertEqual(result.bounty_active, 5)
+        self.assertEqual(result.bounty_completed, 5)
+        self.assertEqual(result.bounty_expired, 5)
+        self.assertEqual(result.bounty_dead, 5)
+        self.assertEqual(result.schema, 'standardSchema')
 
 
 class TestStages(unittest.TestCase):


### PR DESCRIPTION
Increased coverage of timeline_generator.py

Used setupClass, because only read operations are performed during the tests

coverage 43%->48%