### PR TITLE
Updated fulfillment serializer

### DIFF
--- a/bounties_api/std_bounties/serializers.py
+++ b/bounties_api/std_bounties/serializers.py
@@ -75,11 +75,13 @@ class BountyFulfillmentSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'bounty_id',
+            'bountyStage',
             'title',
             'usd_price',
             'tokenSymbol',
             'tokenDecimals',
             'fulfillmentAmount',
+            'calculated_fulfillmentAmount',
             'user']
 
 

--- a/bounties_api/user/management/commands/user_github_fields.py
+++ b/bounties_api/user/management/commands/user_github_fields.py
@@ -1,5 +1,6 @@
 import requests
 import boto3
+from random import random
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 from botocore.exceptions import ClientError
@@ -49,9 +50,10 @@ class Command(BaseCommand):
 
                 if image_r and image_r.status_code == 200:
                     try:
+                        nonce = int(random() * 1000)
                         bucket = 'assets.bounties.network'
-                        key = '{}/userimages/{}.jpg'.format(
-                            settings.ENVIRONMENT, user.public_address)
+                        key = '{}/userimages/{}-{}.jpg'.format(
+                            settings.ENVIRONMENT, user.public_address, nonce)
                         client.put_object(
                             Body=image_r.content,
                             ContentType=image_r.headers['content-type'],
@@ -68,7 +70,6 @@ class Command(BaseCommand):
                 if not user.email and github_email:
                     user.email = github_email
 
-                print('profile image {}'.format(user.profile_image))
                 user.save()
                 logger.info('uploaded for: {}'.format(user.public_address))
 


### PR DESCRIPTION
@villanuevawill @codeluggage I needed the bounty stage to determine if a fulfillment should show pending acceptance or rejected (shows rejected if the bounty is in completed stage). Also figured I would add in the calculated_fulfillmentAmount so I didn't need to calculate it on the client.