### PR TITLE
Temporarily ignore empty RPC response from Infura

### DIFF
--- a/contract_subscriber/index.js
+++ b/contract_subscriber/index.js
@@ -38,12 +38,15 @@ async function handler() {
 			await delay(1000);
 
 		} catch (err) {
-			// include rollbar error message soon
-			rollbar.error(err);
-			console.log(err);
+			// ignore constant RPC response error from Infura temporarily
+			if (err.message !== 'Invalid JSON RPC response: ""') {
+				// include rollbar error message soon
+				rollbar.error(err);
+				console.log(err);
 
-			// exit with error so kubernettes will automatically restart the job
-			process.exit(1);
+				// exit with error so kubernettes will automatically restart the job
+				process.exit(1);
+			}
 		}
 	}
 }


### PR DESCRIPTION
@villanuevawill 

Infura has been experiencing issues due to a regression in `geth` and we are having problems with the contract subscriber due to this. 

This check for the exception message is a temporary band aid solution, which will basically ignore this error and just keep going. 