### PR TITLE
Comments endpoint refactored to use model mixins for viewsets

### DIFF
--- a/bounties_api/std_bounties/urls.py
+++ b/bounties_api/std_bounties/urls.py
@@ -10,12 +10,12 @@ router.register(r'^bounty', views.BountyViewSet)
 router.register(r'^fulfillment', views.FulfillmentViewSet)
 router.register(r'^category', views.CategoryViewSet)
 router.register(r'^reviews', views.ReviewsViewSet, 'user_reviews')
+router.register(r'^bounty/(?P<bounty_id>\d+)/comment', views.BountyComments, 'bounty_comments')
 
 urlpatterns = [
     url(r'^leaderboard/issuer/$', views.LeaderboardIssuer.as_view()),
     url(r'^leaderboard/fulfiller/$', views.LeaderboardFulfiller.as_view()),
     url(r'^token/$', views.Tokens.as_view()),
     url(r'^bounty/(?P<bounty_id>\d+)/fulfillment/(?P<fulfillment_id>\d+)/review/$', views.SubmissionReviews.as_view()),
-    url(r'^bounty/(?P<bounty_id>\d+)/comment/$', views.BountyComments.as_view()),
     url(r'^', include(router.urls)),
 ]

--- a/bounties_api/std_bounties/views.py
+++ b/bounties_api/std_bounties/views.py
@@ -105,7 +105,7 @@ class BountyComments(mixins.ListModelMixin,
         return [permission() for permission in permission_classes]
 
     def get_queryset(self):
-        return Comment.objects.filter(bounty__id=self.kwargs['bounty_id'])
+        return Comment.objects.filter(bounty__id=self.kwargs['bounty_id']).order_by('-created')
 
     def post(self, request, bounty_id):
         bounty = get_object_or_404(Bounty, bounty_id=bounty_id)

--- a/bounties_api/std_bounties/views.py
+++ b/bounties_api/std_bounties/views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework import mixins
 from django.db import connection
 from django.db.models import Count
 from django.http import JsonResponse, Http404, HttpResponse
@@ -92,18 +93,19 @@ class SubmissionReviews(APIView):
         return JsonResponse(data=serializer.data)
 
 
-class BountyComments(APIView):
+class BountyComments(mixins.ListModelMixin,
+                     viewsets.GenericViewSet):
+
+    serializer_class = CommentSerializer
+
     def get_permissions(self):
         permission_classes = []
         if self.request.method == 'POST':
             permission_classes = [AuthenticationPermission]
         return [permission() for permission in permission_classes]
 
-    def get(self, request, bounty_id):
-        get_object_or_404(Bounty, bounty_id=bounty_id)
-        comments = Comment.objects.filter(bounty__id=bounty_id)
-        serializer = CommentSerializer(comments, many=True)
-        return JsonResponse(serializer.data, safe=False)
+    def get_queryset(self):
+        return Comment.objects.filter(bounty__id=self.kwargs['bounty_id'])
 
     def post(self, request, bounty_id):
         bounty = get_object_or_404(Bounty, bounty_id=bounty_id)


### PR DESCRIPTION
@villanuevawill @codeluggage pretty simple PR. Just switch the comments over to the `ListModelMixin` so that we would get `count`, `results`, etc from the request instead of just an array.