### PR TITLE
Add revisions data to bounty

### DIFF
--- a/bounties_api/std_bounties/client_helpers.py
+++ b/bounties_api/std_bounties/client_helpers.py
@@ -90,6 +90,7 @@ def map_bounty_data(data_hash, bounty_id):
         'issuer_address': data_issuer.get(
             'address',
             ''),
+        'revisions': data.get('revisions', None),
         'data_issuer': data_issuer,
         'data': ipfs_hash,
         'data_json': str(data_JSON),


### PR DESCRIPTION
@villanuevawill @codeluggage pulled off the number of revisions from the ipfs data and plopped it into the db. I'm defaulting to `None` so it won't show any revisions on the frontend for older bounties, but newer ones will have the revisions listed on their bounty page. Let me know if y'all have a better default. Cheers