### PR TITLE
Fix fulfilment description

### DIFF
--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -48,6 +48,7 @@ class Email:
         notification_name = kwargs['notification_name']
         review = kwargs.get('review')
         comment = kwargs.get('comment')
+        fulfillment_description = kwargs.get('fulfillment_description', '')
         issuer = user
 
         if notification_name.__class__ != int:
@@ -151,7 +152,8 @@ class Email:
             'from_user_email': from_user and from_user.email,
             'review': review and review.review,
             'rating': review and '{}/5'.format(review.rating),
-            'comment': comment and comment.text
+            'comment': comment and comment.text,
+            'fulfillment_description': fulfillment_description
         })
 
     def render(self):

--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -57,6 +57,7 @@ class NotificationClient:
             from_user=fulfillment.user,
             string_data=string_data_issuer,
             subject='You Received a New Submission',
+            description=fulfillment.description,
             notification_created=event_date,
             is_activity=False)
 

--- a/bounties_api/notifications/templates/completedBounty.html
+++ b/bounties_api/notifications/templates/completedBounty.html
@@ -634,7 +634,7 @@
 
 														<p style="margin: 0px; display: inline-block; ">
 															<b style="color: #A09CA8; font-weight: 400; font-size: 12px;">Submission Description:</b></br>
-															<b style="color: #4A93FF; font-size: 0.875rem; font-weight: 400; color: #615E67; ">{{ submission_description }}</b>
+															<b style="color: #4A93FF; font-size: 0.875rem; font-weight: 400; color: #615E67; ">{{ fulfillment_description }}</b>
 														</p>
 
                         </td>


### PR DESCRIPTION
Use description from fulfillment instead of bounty for email template. Several of these references have been missing, and it's looking messier and messier. A refactor and more functional approach would possibly make this cleaner.