### PR TITLE
added ordering filter to fulfillments endpoint

### DIFF
--- a/bounties_api/std_bounties/views.py
+++ b/bounties_api/std_bounties/views.py
@@ -164,7 +164,11 @@ class FulfillmentViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = FulfillmentSerializer
     queryset = Fulfillment.objects.all().select_related('bounty')
     filter_class = FulfillmentsFilter
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (OrderingFilter, DjangoFilterBackend,)
+    ordering_fields = (
+        'fulfillment_created',
+        'usd_price'
+    )
 
 
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
@villanuevawill @codeluggage needed to add this so i can order the submissions on the whitelabel from newest to oldest