### PR TITLE
Fix double text in profile update notification

### DIFF
--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -390,4 +390,4 @@ class NotificationClient:
             from_user=None,
             notification_created=datetime.utcnow(),
             string_data=string_data,
-            subject='You Updated Your Profile')
+            subject='')


### PR DESCRIPTION
Pass empty subject for profile update because it is redundant.