### PR TITLE
Fix email description switcheroo

### DIFF
--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -57,7 +57,7 @@ class Email:
         notification_name = kwargs['notification_name']
         review = kwargs.get('review')
         comment = kwargs.get('comment')
-        fulfillment_description = kwargs.get('fulfillment_description', '')
+        description = kwargs.get('fulfillment_description', '')
         preview_text = kwargs.get('string_data', '')
 
         if notification_name.__class__ != int:
@@ -75,11 +75,13 @@ class Email:
         remaining = create_decimal(bounty.calculated_balance).normalize()
         token_amount = create_decimal(
             bounty.calculated_fulfillmentAmount).normalize()
-        
-        if len(fulfillment_description) > self.max_description_length:
+
+        if len(description) > self.max_description_length:
             # Cut off at the closest word after the limit
-            fulfillment_description = wrap(fulfillment_description,
-                self.max_description_length)[0] + ' ...'
+            description = wrap(
+                description,
+                self.max_description_length
+            )[0] + ' ...'
 
         title = bounty.title
         if len(title) > self.max_title_length:
@@ -127,7 +129,7 @@ class Email:
             'usd_amount_remaining': remaining_usd,
             'added_amount': added_amount,
             'remaining_submissions': remaining_submissions,
-            'fulfillment_description': fulfillment_description,
+            'fulfillment_description': description,
             'issuer_name': issuer and issuer.name,
             'issuer_address': issuer and shorten_address(
                 issuer.public_address),

--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -75,12 +75,11 @@ class Email:
         remaining = create_decimal(bounty.calculated_balance).normalize()
         token_amount = create_decimal(
             bounty.calculated_fulfillmentAmount).normalize()
-
-        description = bounty.description
-        if len(description) > self.max_description_length:
+        
+        if len(fulfillment_description) > self.max_description_length:
             # Cut off at the closest word after the limit
-            description = wrap(
-                description, self.max_description_length)[0] + ' ...'
+            fulfillment_description = wrap(fulfillment_description,
+                self.max_description_length)[0] + ' ...'
 
         title = bounty.title
         if len(title) > self.max_title_length:
@@ -128,7 +127,7 @@ class Email:
             'usd_amount_remaining': remaining_usd,
             'added_amount': added_amount,
             'remaining_submissions': remaining_submissions,
-            'submission_description': description,
+            'fulfillment_description': fulfillment_description,
             'issuer_name': issuer and issuer.name,
             'issuer_address': issuer and shorten_address(
                 issuer.public_address),
@@ -159,7 +158,6 @@ class Email:
             'rating': review and '{}/5'.format(review.rating),
             'rating_color': review and Email.rating_color(review.rating),
             'comment': comment and comment.text,
-            'fulfillment_description': fulfillment_description,
             'MC_PREVIEW_TEXT': preview_text
         })
 

--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -57,7 +57,7 @@ class NotificationClient:
             from_user=fulfillment.user,
             string_data=string_data_issuer,
             subject='You Received a New Submission',
-            description=fulfillment.description,
+            fulfillment_description=fulfillment.description,
             notification_created=event_date,
             is_activity=False)
 
@@ -121,6 +121,7 @@ class NotificationClient:
             from_user=bounty.user,
             string_data=string_data_fulfiller,
             subject='Your Submission was Accepted',
+            fulfillment_description=fulfillment.description,
             is_activity=False,
             string_data_email=string_data_fulfiller_email,
             notification_created=event_date,

--- a/bounties_api/notifications/templates/fulfillmentUpdated.html
+++ b/bounties_api/notifications/templates/fulfillmentUpdated.html
@@ -634,7 +634,7 @@
 
 														<p style="margin: 0px; display: inline-block; ">
 															<b style="color: #A09CA8; font-weight: 400; font-size: 12px;">Submission Description:</b></br>
-															<b style="color: #4A93FF; font-size: 0.875rem; font-weight: 400; color: #615E67; ">{{ submission_description }}</b>
+															<b style="color: #4A93FF; font-size: 0.875rem; font-weight: 400; color: #615E67; ">{{ fulfillment_description }}</b>
 														</p>
 
                         </td>

--- a/bounties_api/notifications/templates/submissionAccepted.html
+++ b/bounties_api/notifications/templates/submissionAccepted.html
@@ -634,7 +634,7 @@
 
 														<p style="margin: 0px; display: inline-block; ">
 															<b style="color: #A09CA8; font-weight: 400; font-size: 12px;">Submission Description:</b></br>
-															<b style="color: #4A93FF; font-size: 0.875rem; font-weight: 400; color: #615E67; ">{{ submission_description }}</b>
+															<b style="color: #4A93FF; font-size: 0.875rem; font-weight: 400; color: #615E67; ">{{ fulfillment_description }}</b>
 														</p>
 
                         </td>


### PR DESCRIPTION
Fix misconception about which descriptions were meant to send with emails, only use fulfillment descriptions and avoid the bounty description completely.

In essence this means that we never send a bounty description by email notification, only the description coming from the event itself. 