### PR TITLE
Copy change to make comment notification user agnostic

### DIFF
--- a/bounties_api/notifications/templates/commentOnBounty.html
+++ b/bounties_api/notifications/templates/commentOnBounty.html
@@ -13,7 +13,7 @@
 		<meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>Someone just commented on your bounty!</title>
+		<title>Someone just commented on {{ bounty_title }}</title>
 		<link href="https://rsms.me/inter/inter-ui.css" rel="stylesheet" type="text/css">
     <style type="text/css">
 		p{


### PR DESCRIPTION
Now that more users than just the issuer receive a notification when a comment has been posted on a bounty they're involved with, we want that to reflect in the copy.