### PR TITLE
Correct decimal rounding for dollars and tokens

### DIFF
--- a/bounties_api/bounties/utils.py
+++ b/bounties_api/bounties/utils.py
@@ -1,5 +1,5 @@
 import datetime
-from decimal import Decimal
+from decimal import Decimal, Context, ROUND_HALF_UP
 import time
 import logging
 from django.conf import settings
@@ -7,6 +7,8 @@ from django.conf import settings
 logger = logging.getLogger('django')
 max_datetime = datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)
 max_time_stamp = time.mktime(max_datetime.timetuple())
+create_token_decimals = Context(prec=6).create_decimal
+create_usd_decimals = Context(prec=3).create_decimal
 
 
 def sqlGenerateOrList(param_name, count, operation):
@@ -102,3 +104,13 @@ def profile_url_for(public_address, platform=None):
 
 def shorten_address(address):
     return '{}...{}'.format(address[:6], address[-4:])
+
+
+def token_decimals(tokens):
+    return create_token_decimals(tokens).quantize(
+        Decimal('.00001'), rounding=ROUND_HALF_UP).normalize()
+
+
+def usd_decimals(tokens):
+    return create_usd_decimals(tokens).quantize(
+        Decimal('.01'), rounding=ROUND_HALF_UP).normalize()

--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -15,8 +15,8 @@ from bounties.settings import ENVIRONMENT
 
 default_image = ('https://gallery.mailchimp.com/03351ad14a86e9637146ada2a'
                  '/images/fae20fec-36ab-4594-9753-643c04e0ab9a.png')
-token_decimals = Context(prec=6).create_decimal
-usd_decimals = Context(prec=3).create_decimal
+create_token_decimals = Context(prec=6).create_decimal
+create_usd_decimals = Context(prec=3).create_decimal
 
 
 class Email:
@@ -38,13 +38,13 @@ class Email:
 
     @staticmethod
     def token_decimals(tokens):
-        return token_decimals(tokens).normalize().quantize(
-            Decimal('.01'), rounding=ROUND_HALF_UP)
+        return create_token_decimals(tokens).quantize(
+            Decimal('.00001'), rounding=ROUND_HALF_UP).normalize()
 
     @staticmethod
     def usd_decimals(tokens):
-        return usd_decimals(tokens).normalize().quantize(
-            Decimal('.00001'), rounding=ROUND_HALF_UP)
+        return create_usd_decimals(tokens).quantize(
+            Decimal('.01'), rounding=ROUND_HALF_UP).normalize()
 
     @staticmethod
     def render_categories(categories):

--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -12,9 +12,8 @@ from notifications.notification_templates import (
     email_templates
 )
 from bounties.utils import (
-    calculate_token_value
-    token_decimals,
-    usd_decimals
+    calculate_token_value,
+    token_decimals
 )
 import logging
 

--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -1,4 +1,4 @@
-from decimal import Decimal, Context
+from decimal import Decimal
 from datetime import datetime
 from std_bounties.models import Fulfillment, Bounty, Comment
 from user.models import User
@@ -11,7 +11,11 @@ from notifications.notification_templates import (
     notification_templates,
     email_templates
 )
-from bounties.utils import calculate_token_value
+from bounties.utils import (
+    calculate_token_value
+    token_decimals,
+    usd_decimals
+)
 import logging
 
 logger = logging.getLogger('django')
@@ -214,10 +218,9 @@ class NotificationClient:
                 transaction_from.lower()))
             return
 
-        token_decimal = Context(prec=6).create_decimal
-        amount = '{} {}'.format(bounty.tokenSymbol, token_decimal(
-            calculate_token_value(int(Decimal(inputs['value'])), bounty.tokenDecimals)
-        ).normalize())
+        amount = '{} {}'.format(bounty.tokenSymbol, token_decimals(
+            calculate_token_value(
+                int(Decimal(inputs['value'])), bounty.tokenDecimals)))
 
         added_string_data = notification_templates['ContributionAdded'].format(
             bounty_title=bounty.title, amount=amount)


### PR DESCRIPTION
- Switch to using a function
- Quantize first, then normalize
- Set precision for usd and tokens, but use quantize for the final decimal points 