### PR TITLE
CircleCI docker image building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,21 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
 
-
       - store_artifacts:
           path: test-reports
           destination: test-reports
+
+      - run:
+          name: build docker image
+          command: |
+            docker build ./bounties_api --tag consensysbounties/std_bounties:$CIRCLE_SHA1
+
+      - run:
+          name: log in to docker hub
+          command: |
+            docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+
+      - run:
+          name: upload docker image
+          command: |
+            docker push consensysbounties/std_bounties:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
 
       - run:
           name: Run django tests
-          command: docker-compose -f docker-compose-circleci-test.yml run bounties_api python manage.py test
+          command: docker-compose -f docker-compose-circleci-test.yml run bash -c "sleep 5 && bounties_api python manage.py test"
+
 
       # - run:
       #     name: log in to docker hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run:
           name: Run django tests
-          command: docker-compose -f docker-compose-circleci-test.yml run bash -c "sleep 5 && bounties_api python manage.py test"
+          command: docker-compose -f docker-compose-circleci-test.yml run bounties_api bash -c "sleep 5 && python manage.py test"
 
 
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,8 @@
-# Python CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-python/ for more details
-#
 version: 2
 jobs:
   build:
     machine:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       image: circleci/classic:latest
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
 
@@ -21,46 +10,26 @@ jobs:
       - checkout
 
       - run:
-          name: Install codecov
-          command: |
-            pip install codecov==2.0.15
-
-      - run:
-          name: python linter
+          name: Install flake8 for python linting
           command: |
             pyenv global 3.5.2
             pip3 install flake8==3.5.0
-            flake8 --ignore=E501,F405,W191
-
-      # run tests!
-      # this example uses Django's built-in test-runner
-      # other common Python testing frameworks include pytest and nose
-      # https://pytest.org
-      # https://nose.readthedocs.io
 
       - run:
-          name: build docker image
-          command: |
-            docker build ./bounties_api --tag consensysbounties/std_bounties:$CIRCLE_SHA1
-            
+          name: Lint python code
+          command: flake8 --ignore=E501,F405,W191
+
+      - run:
+          name: Build docker image
+          command: docker build ./bounties_api --tag consensysbounties/std_bounties:$CIRCLE_SHA1
+
       - run:
           name: Create docker postgres volume
-          command: |
-            docker volume create --name psql_bounties
+          command: docker volume create --name psql_bounties
 
       - run:
-          name: run django tests
-          command: |
-            docker-compose -f docker-compose-circleci-test.yml run bounties_api python manage.py test
-
-      - run:
-          name: codecov upload
-          command: |
-            bash <(curl -s https://codecov.io/bash)
-
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
+          name: Run django tests
+          command: docker-compose -f docker-compose-circleci-test.yml run bounties_api python manage.py test
 
       # - run:
       #     name: log in to docker hub
@@ -71,3 +40,15 @@ jobs:
       #     name: upload docker image
       #     command: |
       #       docker push consensysbounties/std_bounties:$CIRCLE_SHA1
+
+      - run:
+          name: Install codecov
+          command: pip install codecov==2.0.15
+
+      - run:
+          name: Run and upload code coverage
+          command: bash <(curl -s https://codecov.io/bash)
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,14 @@ jobs:
       # https://nose.readthedocs.io
 
       - run:
+          name: build docker image
+          command: |
+            docker build ./bounties_api --tag consensysbounties/std_bounties:$CIRCLE_SHA1
+
+      - run:
           name: run django tests
           command: |
-            docker-compose -f docker-compose-test.yml run bounties_api python manage.py test
+            docker-compose -f docker-compose-circleci-test.yml run bounties_api python manage.py test
 
       - run:
           name: codecov upload
@@ -61,17 +66,12 @@ jobs:
           path: test-reports
           destination: test-reports
 
-      - run:
-          name: build docker image
-          command: |
-            docker build ./bounties_api --tag consensysbounties/std_bounties:$CIRCLE_SHA1
+      # - run:
+      #     name: log in to docker hub
+      #     command: |
+      #       docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
 
-      - run:
-          name: log in to docker hub
-          command: |
-            docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
-
-      - run:
-          name: upload docker image
-          command: |
-            docker push consensysbounties/std_bounties:$CIRCLE_SHA1
+      # - run:
+      #     name: upload docker image
+      #     command: |
+      #       docker push consensysbounties/std_bounties:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,6 @@ jobs:
             pip install codecov==2.0.15
 
       - run:
-          name: Install Docker Compose
-          command: |
-            curl -L https://github.com/docker/compose/releases/download/1.18.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
-            chmod +x ~/docker-compose
-            sudo mv ~/docker-compose /usr/local/bin/docker-compose
-            docker volume create --name redis_bounties
-            docker volume create --name psql_bounties
-
-      - run:
           name: python linter
           command: |
             pyenv global 3.5.2
@@ -51,6 +42,11 @@ jobs:
           name: build docker image
           command: |
             docker build ./bounties_api --tag consensysbounties/std_bounties:$CIRCLE_SHA1
+            
+      - run:
+          name: Create docker postgres volume
+          command: |
+            docker volume create --name psql_bounties
 
       - run:
           name: run django tests

--- a/docker-compose-circleci-test.yml
+++ b/docker-compose-circleci-test.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: bounties
+    volumes:
+      - psql_bounties:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  bounties_api:
+    image: consensysbounties/std_bounties:${CIRCLE_SHA1}
+    restart: always
+    env_file:
+      - .env
+    command: bash -c "python3 manage.py makemigrations && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:83"
+    volumes:
+      - ./bounties_api:/code
+    ports:
+      - "8000:83"
+    depends_on:
+      - db
+volumes:
+  psql_bounties:
+    external: true

--- a/docker-compose-circleci-test.yml
+++ b/docker-compose-circleci-test.yml
@@ -10,6 +10,12 @@ services:
       - psql_bounties:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+  redis:
+    image: "redis"
+    volumes:
+      - redis_bounties:/data
+    ports:
+      - "6379:6379"
   bounties_api:
     image: consensysbounties/std_bounties:${CIRCLE_SHA1}
     restart: always
@@ -24,4 +30,6 @@ services:
       - db
 volumes:
   psql_bounties:
+    external: true
+  redis_bounties:
     external: true

--- a/docker-compose-circleci-test.yml
+++ b/docker-compose-circleci-test.yml
@@ -10,12 +10,6 @@ services:
       - psql_bounties:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-  redis:
-    image: "redis"
-    volumes:
-      - redis_bounties:/data
-    ports:
-      - "6379:6379"
   bounties_api:
     image: consensysbounties/std_bounties:${CIRCLE_SHA1}
     restart: always
@@ -30,6 +24,4 @@ services:
       - db
 volumes:
   psql_bounties:
-    external: true
-  redis_bounties:
     external: true


### PR DESCRIPTION
- Simplify and shorten down our CircleCI config, removing duplicate docker-compose install
- Reorder CircleCI build steps to use less time in case something fails
- Build the docker image for the current commit
- Use the built docker image for the tests 
- Reduce the services used by tests to only Postgres and BountiesAPI (when we add more integration tests, we can add in these services again)

Remaining work: 

- [ ] Enable login and pushing to Docker Hub when username/pw is fixed 

How to test: 

- Check out this branch
- Make a new branch, change something
- Push it up to github
- Look for your commit in https://circleci.com/gh/Bounties-Network/BountiesAPI, click into the build and see that everything runs without failing