### PR TITLE
Fix remaining submissions reference in contribution email

### DIFF
--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -94,7 +94,9 @@ class Email:
 
         remaining_submissions = 0
 
-        if notification_name == constants.BOUNTY_EXPIRED:
+        if (notification_name == constants.BOUNTY_EXPIRED or
+                notification_name == constants.CONTRIBUTION_RECEIVED or
+                notification_name == constants.CONTRIBUTION_ADDED):
             remaining_submissions = Fulfillment.objects.filter(
                 bounty_id=bounty.id,
                 accepted=False,


### PR DESCRIPTION
@villanuevawill without this check we'd query when we didn't need the count. With all these new emails, it is starting to get a little unwieldy. Any thoughts on splitting this? 