### PR TITLE
Lookup field is now uid

### DIFF
--- a/bounties_api/std_bounties/views.py
+++ b/bounties_api/std_bounties/views.py
@@ -136,6 +136,7 @@ class BountyComments(mixins.ListModelMixin,
 class DraftBountyWriteViewSet(viewsets.ModelViewSet):
     queryset = DraftBounty.objects.filter(on_chain=False)
     serializer_class = DraftBountyWriteSerializer
+    lookup_field = 'uid'
     filter_class = DraftBountiesFilter
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('issuer',)


### PR DESCRIPTION
This is related to:
https://github.com/Bounties-Network/Explorer/pull/179

Draft bounties are now looked up by their UID or hash field. This keeps sharable links private.

Associated task:
- https://trello.com/c/OYQTFSWU/6-draft-links-should-be-open-but-should-just-be-based-on-the-uuid-hash-this-makes-it-sharable