### PR TITLE
Fix Gitcoin bounties' deadlines

### DIFF
--- a/bounties_api/std_bounties/client_helpers.py
+++ b/bounties_api/std_bounties/client_helpers.py
@@ -1,6 +1,7 @@
 import json
 import requests
 from decimal import Decimal
+from datetime import datetime
 
 from web3 import Web3, HTTPProvider
 from web3.contract import ConciseContract
@@ -99,8 +100,8 @@ def map_bounty_data(data_hash, bounty_id):
     }
 
     # if 'platform' is gitcoin, also return deadline
-    if metadata.get('platform', '') is 'gitcoin':
-        bounty.update({'deadline': data.get('expire_date', '')})
+    if meta.get('platform', '') == 'gitcoin' and 'expire_date' in data:
+        bounty.update({'deadline': datetime.utcfromtimestamp(int(data.get('expire_date')))})
 
     return bounty
 


### PR DESCRIPTION
@villanuevawill @codeluggage it looks like the logic to retrieve the `expiry_date` was never triggered because it failed the `if metadata.get('platform', '') is 'gitcoin'` check. To fix all affected bounties already in the system, please use the follow script:

```
from std_bounties.models import Bounty
from datetime import datetime
import json

bounties = Bounty.objects.all()

for bounty in bounties:
	data_JSON = bounty.data_json
	data = json.loads(data_JSON)

	meta = data.get('meta', {})
	if 'payload' in data:
		data = data.get('payload')

	if meta.get('platform', '') == 'gitcoin' and 'expire_date' in data:
		bounty.deadline = datetime.utcfromtimestamp(int(data.get('expire_date', '')))
		bounty.save()
```