### PR TITLE
Fix average rating email

### DIFF
--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -139,7 +139,7 @@ class Email:
 
         rating_count = ratings and ratings.count() or 0
         average_rating = ratings and ratings.aggregate(
-            Avg('rating')).get('rating__avg') or '?'
+            Avg('rating')).get('rating__avg') or 0
 
         self.__dict__.update({
             'bounty': bounty,

--- a/bounties_api/notifications/email.py
+++ b/bounties_api/notifications/email.py
@@ -45,9 +45,9 @@ class Email:
 
     @staticmethod
     def rating_color(rating):
-        if rating >= 0.8:
+        if rating >= 4:
             return '#6FC78D'  # 'brand-green'
-        elif rating >= 0.5:
+        elif rating >= 3:
             return '#FBAA31'  # 'brand-orange'
         else:
             return '#D14545'  # 'brand-red'

--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -416,10 +416,11 @@ class NotificationClient:
         bounty = Bounty.objects.get(id=bounty_id)
         string_data = notification_templates['RatingIssued'].format(
             bounty_title=bounty.title)
+        notification_name = notifications['RatingIssued']
         create_bounty_notification(
             bounty=bounty,
-            uid='{}-{}'.format(uid, reviewer.id),
-            notification_name=notifications['RatingIssued'],
+            uid='{}-{}-{}'.format(uid, reviewer.id, notification_name),
+            notification_name=notification_name,
             user=reviewer,
             from_user=reviewee,
             string_data=string_data,
@@ -438,10 +439,11 @@ class NotificationClient:
         bounty = Bounty.objects.get(id=bounty_id)
         string_data = notification_templates['RatingReceived'].format(
             bounty_title=bounty.title)
+        notification_name = notifications['RatingReceived']
         create_bounty_notification(
             bounty=bounty,
-            uid='{}-{}'.format(uid, reviewee.id),
-            notification_name=notifications['RatingReceived'],
+            uid='{}-{}-{}'.format(uid, reviewee.id, notification_name),
+            notification_name=notification_name,
             user=reviewee,
             from_user=reviewer,
             string_data=string_data,

--- a/bounties_api/notifications/templates/receivedRating.html
+++ b/bounties_api/notifications/templates/receivedRating.html
@@ -678,7 +678,7 @@
                     <tbody>
                         <tr>
                             <td align="center" valign="middle" class="mcnButtonContent" style="font-family: 'Inter UI', sans-serif; font-size: 18px; padding: 18px;">
-                                <a class="mcnButton " title="Find Out More" href="{{ url }}" target="_blank" style="font-family:'Inter UI', sans-serif; font-weight: 400;letter-spacing: -0.5px;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF; font-size: 1rem !important">View Profile</a>
+                                <a class="mcnButton " title="Find Out More" href="{{ user_address_link }}" target="_blank" style="font-family:'Inter UI', sans-serif; font-weight: 400;letter-spacing: -0.5px;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF; font-size: 1rem !important">View Profile</a>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
@villanuevawill @c-o-l-o-r the rating emails were not being rendered with data, and needed to pull in the average calculation based on the sender and receiver of the rating. 

I also fixed colours in the email, and made deduplication more unique for ratings to guard against an edge case I ran into when testing rating email delivery. This makes the deduplication differ between issued and received. 

The rating is being rounded to 2 digits when it's not an exact number, in the text below the main email graphics. Not in the circle, just in the text. 