### PR TITLE
Less sensitive CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2
+    patch:
+      default:
+        threshold: 2


### PR DESCRIPTION
- Adds `codecov.yml`
- Sets threshold to 2% to fail