### PR TITLE
Ignore emails for users that don't have an email set yet

### DIFF
--- a/bounties_api/notifications/notification_helpers.py
+++ b/bounties_api/notifications/notification_helpers.py
@@ -66,6 +66,10 @@ def create_notification(**kwargs):
         },
     )
 
+    # from here on out, all we care about is email
+    if not user.email:
+        return
+
     email_settings = user.settings.emails
     activity_emails = email_settings['activity']
 


### PR DESCRIPTION
@villanuevawill @c-o-l-o-r 

Set it at the top as all the following code has no use without an email being set already. The field on the model is:
```
    email = models.CharField(max_length=128, blank=True)
```

Skips sending an email when creating a new user, commenting on a bounty, and then someone else comments on the same bounty. 