### PR TITLE
Force no line break for USD price in emails

### DIFF
--- a/bounties_api/notifications/templates/bountyExpired.html
+++ b/bounties_api/notifications/templates/bountyExpired.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/bountyTransferReceived.html
+++ b/bounties_api/notifications/templates/bountyTransferReceived.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/bountyTransferSent.html
+++ b/bounties_api/notifications/templates/bountyTransferSent.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/commentOnBounty.html
+++ b/bounties_api/notifications/templates/commentOnBounty.html
@@ -611,7 +611,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/contributionReceived.html
+++ b/bounties_api/notifications/templates/contributionReceived.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/fulfillmentSubmitted.html
+++ b/bounties_api/notifications/templates/fulfillmentSubmitted.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/fulfillmentUpdated.html
+++ b/bounties_api/notifications/templates/fulfillmentUpdated.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/receivedRating.html
+++ b/bounties_api/notifications/templates/receivedRating.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 

--- a/bounties_api/notifications/templates/submissionAccepted.html
+++ b/bounties_api/notifications/templates/submissionAccepted.html
@@ -610,7 +610,7 @@
                         </td>
 												<td valign="top" class="mcnTextContent" style="padding:24px 24px 0.25rem 24px; width: 30%;">
 
-                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem;">${{ usd_amount }}</h2>
+                            <h2 style="color: #5A28C6; font-size: 1.563rem; text-align: right; line-height: 1.563rem; word-break:initial;">${{ usd_amount }}</h2>
 														<p style="color: #A09CA8; font-size: 0.75rem; text-align: right; line-height: 0.75rem; margin-top: 0.5rem; font-weight: 400">{{ token_amount }} {{ token }}</p>
 
 


### PR DESCRIPTION
Trello: https://trello.com/c/wzNNbtQD

This makes sure that the USD price never line breaks, which is important for smaller mobile screens.