### PR TITLE
Avoid word break on the reply button for mobile

### DIFF
--- a/bounties_api/notifications/templates/commentOnBounty.html
+++ b/bounties_api/notifications/templates/commentOnBounty.html
@@ -643,7 +643,7 @@
 
 
 
-														<a href="{{ url }}" style="color: #4A93FF; font-size: 0.875rem; padding: 0.5rem 1rem; text-decoration: none; color: white; background-color: #4A93FF; border-radius: 3px; float: right;">Reply</a></p>
+														<a href="{{ url }}" style="color: #4A93FF; font-size: 0.875rem; padding: 0.5rem 1rem; text-decoration: none; color: white; background-color: #4A93FF; border-radius: 3px; float: right; word-break:initial;">Reply</a></p>
 
                         </td>
 											</tr>


### PR DESCRIPTION
Trello: https://trello.com/c/wzNNbtQD

This was missing from the previous PR, I did not catch that there were 2 pictures in the Trello card.