### PR TITLE
Always use receiver of review as URL target

### DIFF
--- a/bounties_api/notifications/notification_client.py
+++ b/bounties_api/notifications/notification_client.py
@@ -420,7 +420,8 @@ class NotificationClient:
         notification_name = notifications['RatingIssued']
         create_rating_notification(
             bounty=bounty,
-            uid='{}-{}-{}'.format(uid, reviewer.id, notification_name),
+            uid='{}-{}-{}-{}'.format(
+                bounty_id, uid, reviewer.id, notification_name),
             notification_name=notification_name,
             user=reviewer,
             from_user=reviewee,
@@ -443,7 +444,8 @@ class NotificationClient:
         notification_name = notifications['RatingReceived']
         create_rating_notification(
             bounty=bounty,
-            uid='{}-{}-{}'.format(uid, reviewee.id, notification_name),
+            uid='{}-{}-{}-{}'.format(
+                bounty_id, uid, reviewee.id, notification_name),
             notification_name=notification_name,
             user=reviewee,
             from_user=reviewer,

--- a/bounties_api/notifications/notification_helpers.py
+++ b/bounties_api/notifications/notification_helpers.py
@@ -27,8 +27,9 @@ def create_profile_updated_notification(*args, **kwargs):
 
 def create_rating_notification(**kwargs):
     bounty = kwargs.get('bounty')
-    user = kwargs.get('user')
     issuer = bounty.user
+    review = kwargs.get('review')
+    user = review.reviewee
 
     reviewee = 'fulfiller'
     if user.public_address == issuer.public_address:

--- a/bounties_api/utils/dashboard_notification_update.py
+++ b/bounties_api/utils/dashboard_notification_update.py
@@ -1,0 +1,72 @@
+from notifications.models import Notification, DashboardNotification
+from bounties.utils import profile_url_for
+from std_bounties.models import Bounty, Fulfillment, Review
+
+
+def fix_it_all():
+    for notification in Notification.objects.filter(notification_name=19):
+        print()
+        print('looping with notification {}'.format(notification.__dict__))
+        print()
+        dn = DashboardNotification.objects.get(id=notification.id)
+        print()
+        print('looping with dn {}'.format(dn.__dict__))
+        print()
+        title = dn.data['bounty_title']
+        bounties = Bounty.objects.filter(title=title)
+        if len(bounties) > 1:
+            print()
+            print()
+            print('GOT MULTIPLE BOUNTIES FOR TITLE: {}'.format(title))
+            print()
+            print()
+            continue
+
+        bounty = bounties[0]
+        print()
+        print('looping with bounty {}'.format(bounty.__dict__))
+        print()
+
+        fulfillments = Fulfillment.objects.filter(bounty_id=bounty.bounty_id)
+        for fulfillment in fulfillments:
+            print()
+            print('looping with fulfillment {}'.format(fulfillment.__dict__))
+            print()
+
+            if fulfillment.issuer_review_id:
+                fix_issuer(fulfillment, dn)
+
+
+def fix_issuer(fulfillment, dn):
+    review = Review.objects.get(id=fulfillment.issuer_review_id)
+    issuer = Bounty.objects.get(id=fulfillment.bounty_id).issuer
+    update_dash_notification(issuer, review.reviewee, dn)
+
+
+# WARNING - This will modify notifications in the database
+# Use with caution and test on your local database first!
+
+def update_dash_notification(issuer_address, user, dash):
+    reviewee = 'fulfiller'
+
+    print()
+    print('running update_dash_notification with {} {} {}'.format(
+        issuer_address, user, dash))
+    print()
+
+    if user.public_address == issuer_address:
+        # Rating for the issuer from the fulfiller
+        reviewee = 'issuer'
+
+    profile_url = profile_url_for(user.public_address)
+    url = profile_url + '?reviews=true&{}=true'.format(reviewee)
+    print('changing dash notification from:')
+    print(dash.__dict__)
+    print()
+    dash.data['link'] = url
+    print('to:')
+    print(dash.__dict__)
+    print()
+
+    print('NOT UPDATING (uncomment here to actually update)')
+    # dash.save()

--- a/bounties_api/utils/dashboard_notification_update.py
+++ b/bounties_api/utils/dashboard_notification_update.py
@@ -13,7 +13,7 @@ def fix_it_all():
         print('looping with dn {}'.format(dn.__dict__))
         print()
         title = dn.data['bounty_title']
-        bounties = Bounty.objects.filter(title=title)
+        bounties = Bounty.objects.filter(title=title).exclude(bountyStage=2)
         if len(bounties) > 1:
             print()
             print()


### PR DESCRIPTION
Trello: https://trello.com/c/iQLlep6Q

The dashboard notification for review issued was using the wrong profile URL. 

- New dashboard notifications now use the proper user for the issued dashboard notification
- The bounty ID was added to the UID of the notifications, making it easier to look them up in the future
- A one-of utility script was added to update past dashboard notifications

Plan for updating past notifications is: 

1. Deploy
1. Change the script on the server to comment out the `dash.save()` call, so it will actually save
1. Run the script, taking care to note the output of `GOT MULTIPLE BOUNTIES FOR TITLE:`
1. Manually edit the occurrences of the multiple title bounties where the link is wrong
1. Done! :)