### PR TITLE
Gitcoin should never have private fulfillments

### DIFF
--- a/bounties_api/std_bounties/client_helpers.py
+++ b/bounties_api/std_bounties/client_helpers.py
@@ -102,6 +102,8 @@ def map_bounty_data(data_hash, bounty_id):
     # if 'platform' is gitcoin, also return deadline
     if meta.get('platform', '') == 'gitcoin' and 'expire_date' in data:
         bounty.update({'deadline': datetime.utcfromtimestamp(int(data.get('expire_date')))})
+    if meta.get('platform', '') == 'gitcoin':
+        bounty.update({'private_fulfillments': False})
 
     return bounty
 


### PR DESCRIPTION
@codeluggage @c-o-l-o-r gitcoin fulfillments should default to public. All of their work is open and on github, so if someone opens a gitcoin bounty, they should be able to see the submissions.