### PR TITLE
hotfix: contract subscriber issue

### DIFF
--- a/contract_subscriber/eventsRetriever.js
+++ b/contract_subscriber/eventsRetriever.js
@@ -32,6 +32,8 @@ async function sendEvents(events) {
 
 			bountyId = bountyId === '-1' ? _bountyId : bountyId;
 
+			console.log({ transactionHash })
+
 			const rawTransaction = await getTransaction(transactionHash);
 			const transactionFrom = rawTransaction.from;
 			const rawContractMethodInputs = abiDecoder.decodeMethod(rawTransaction.input);

--- a/contract_subscriber/eventsRetriever.js
+++ b/contract_subscriber/eventsRetriever.js
@@ -2,7 +2,8 @@ const { cloneDeep, chain } = require('lodash'),
 	  { getAsync } = require('./redis_config'),
 	  { SQS_PARAMS } = require('./constants'),
 	  { abiDecoder, getTransaction, getBlock } = require('./web3_config'),
-	   sqs = require('./sqs_config');
+		sqs = require('./sqs_config'),
+		rollbar = require('./rollbar');
 
 
 async function sendEvents(events) {
@@ -32,11 +33,21 @@ async function sendEvents(events) {
 
 			bountyId = bountyId === '-1' ? _bountyId : bountyId;
 
-			console.log({ transactionHash })
+			console.log({ transactionHash });
 
 			const rawTransaction = await getTransaction(transactionHash);
 			const transactionFrom = rawTransaction.from;
 			const rawContractMethodInputs = abiDecoder.decodeMethod(rawTransaction.input);
+
+			// if the bounty contract is called as an internal transaction, it will fail here
+			// because we use the tx input to populate our database. In the case of internal
+			// transactions, that tx input is the original input to a smart contract wallet
+			// or whatever contract made the internal call to bounties
+			if (!rawContractMethodInputs) {
+				rollbar.error(`Unable to decode transaction input using ABI: ${transactionHash}`);
+				continue;
+			}
+
 			const contractMethodInputs = chain(rawContractMethodInputs.params)
 				.keyBy('name')
 				.mapValues('value')


### PR DESCRIPTION
This skips over transactions that originate from another smart contract and logs them in rollbar so that we can potentially take manual action.